### PR TITLE
Refactor asset paths to be campaign-relative

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -977,7 +977,7 @@ class MainWindow(ctk.CTk):
             output_filename = f"{npc_name.replace(' ', '_')}_portrait.png"
             with open(output_filename, "wb") as f:
                 f.write(downloaded_image.content)
-            GENERATED_FOLDER = "assets/generated"
+            GENERATED_FOLDER = os.path.join(ConfigHelper.get_campaign_dir(), "assets", "generated")
             os.makedirs(GENERATED_FOLDER, exist_ok=True)
             shutil.copy(output_filename, os.path.join(GENERATED_FOLDER, output_filename))
             npc["Portrait"] = self.copy_and_resize_portrait(npc, output_filename)
@@ -1031,7 +1031,7 @@ class MainWindow(ctk.CTk):
             output_filename = f"{creature_name.replace(' ', '_')}_portrait.png"
             with open(output_filename, "wb") as f:
                 f.write(downloaded_image.content)
-            GENERATED_FOLDER = "assets/generated"
+            GENERATED_FOLDER = os.path.join(ConfigHelper.get_campaign_dir(), "assets", "generated")
             os.makedirs(GENERATED_FOLDER, exist_ok=True)
             shutil.copy(output_filename, os.path.join(GENERATED_FOLDER, output_filename))
             creature["Portrait"] = self.copy_and_resize_portrait(creature, output_filename)

--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -9,6 +9,7 @@ from tkinter import Toplevel, messagebox
 from tkinter import ttk
 from modules.ui.image_viewer import show_portrait
 from modules.generic.generic_editor_window import GenericEditorWindow
+from modules.helpers.config_helper import ConfigHelper
 
 # Configure portrait size.
 PORTRAIT_SIZE = (200, 200)
@@ -198,6 +199,10 @@ def insert_npc_table(parent, header, npc_names, open_entity_callback):
 
         # portrait
         portrait_path = data.get("Portrait")
+        if portrait_path and not os.path.isabs(portrait_path):
+            candidate = os.path.join(ConfigHelper.get_campaign_dir(), portrait_path)
+            if os.path.exists(candidate):
+                portrait_path = candidate
         if portrait_path and os.path.exists(portrait_path):
             img = Image.open(portrait_path).resize((40,40), Image.Resampling.LANCZOS)
             photo = CTkImage(light_image=img, size=(40,40))

--- a/modules/generic/entity_selection_dialog.py
+++ b/modules/generic/entity_selection_dialog.py
@@ -4,8 +4,9 @@ from tkinter import messagebox
 from PIL import Image
 from customtkinter import CTkLabel, CTkImage
 from modules.helpers.text_helpers import format_longtext
+from modules.helpers.config_helper import ConfigHelper
 
-PORTRAIT_FOLDER = "assets/portraits"
+PORTRAIT_FOLDER = os.path.join(ConfigHelper.get_campaign_dir(), "assets", "portraits")
 MAX_PORTRAIT_SIZE = (64, 64)
 
 class EntitySelectionDialog(ctk.CTkToplevel):

--- a/modules/generic/export_for_foundry.py
+++ b/modules/generic/export_for_foundry.py
@@ -4,6 +4,7 @@ import shutil
 import zipfile
 from tkinter import filedialog, messagebox
 from modules.generic.generic_model_wrapper import GenericModelWrapper
+from modules.helpers.config_helper import ConfigHelper
 
 # Define the name for the temporary portraits folder and the relative folder name in the ZIP.
 TEMP_PORTRAIT_FOLDER = "temp_portraits"
@@ -59,6 +60,10 @@ def preview_and_export_foundry(self):
         if portrait:
             # Normalize path separators.
             portrait = portrait.replace("\\", "/")
+            if not os.path.isabs(portrait):
+                abs_portrait = os.path.join(ConfigHelper.get_campaign_dir(), portrait)
+                if os.path.exists(abs_portrait):
+                    portrait = abs_portrait
             file_name = os.path.basename(portrait)
             # Copy the portrait file to the temporary folder.
             # Note: You may need to adjust the source path if the portraits are not found relative to the working directory.

--- a/modules/generic/generic_editor_window.py
+++ b/modules/generic/generic_editor_window.py
@@ -990,7 +990,7 @@ class GenericEditorWindow(ctk.CTkToplevel):
             self.portrait_path = self.copy_and_resize_portrait(output_filename)
             self.portrait_label.configure(text=os.path.basename(self.portrait_path))
             #copy the outputfilename file to the assets/generated folder
-            GENERATED_FOLDER = "assets/generated"
+            GENERATED_FOLDER = os.path.join(ConfigHelper.get_campaign_dir(), "assets", "generated")
             os.makedirs(GENERATED_FOLDER, exist_ok=True)
             shutil.copy(output_filename, os.path.join(GENERATED_FOLDER, output_filename))
             os.remove(output_filename)  # Delete the original image file
@@ -1043,7 +1043,8 @@ class GenericEditorWindow(ctk.CTkToplevel):
             self.image_label.configure(text=os.path.basename(self.image_path))
 
     def copy_and_resize_image(self, src_path):
-        IMAGE_FOLDER = "assets/images/map_images"
+        campaign_dir = ConfigHelper.get_campaign_dir()
+        IMAGE_FOLDER = os.path.join(campaign_dir, "assets", "images", "map_images")
         MAX_IMAGE_SIZE = (1920, 1080)
 
         os.makedirs(IMAGE_FOLDER, exist_ok=True)
@@ -1058,7 +1059,8 @@ class GenericEditorWindow(ctk.CTkToplevel):
         return dest_path
 
     def copy_and_resize_portrait(self, src_path):
-        PORTRAIT_FOLDER = "assets/portraits"
+        campaign_dir = ConfigHelper.get_campaign_dir()
+        PORTRAIT_FOLDER = os.path.join(campaign_dir, "assets", "portraits")
         MAX_PORTRAIT_SIZE = (1024, 1024)
 
         os.makedirs(PORTRAIT_FOLDER, exist_ok=True)

--- a/modules/generic/generic_list_view.py
+++ b/modules/generic/generic_list_view.py
@@ -8,8 +8,9 @@ from tkinter import ttk, messagebox
 from PIL import Image, ImageTk
 from modules.generic.generic_editor_window import GenericEditorWindow
 from modules.ui.image_viewer import show_portrait
+from modules.helpers.config_helper import ConfigHelper
 
-PORTRAIT_FOLDER = "assets/portraits"
+PORTRAIT_FOLDER = os.path.join(ConfigHelper.get_campaign_dir(), "assets", "portraits")
 MAX_PORTRAIT_SIZE = (1024, 1024)
 ctk.set_appearance_mode("Dark")
 ctk.set_default_color_theme("blue")

--- a/modules/helpers/config_helper.py
+++ b/modules/helpers/config_helper.py
@@ -36,4 +36,10 @@ class ConfigHelper:
         with open(file_path, "w", encoding="utf-8") as configfile:
             config.write(configfile)
 
+    @classmethod
+    def get_campaign_dir(cls):
+        """Return the directory containing the configured database file."""
+        db_path = cls.get("Database", "path", fallback="default_campaign.db")
+        return os.path.abspath(os.path.dirname(db_path))
+
 

--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -17,12 +17,13 @@ from PIL import Image, ImageTk, ImageDraw
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.helpers.template_loader import load_template
 from modules.helpers.text_helpers import format_longtext
+from modules.helpers.config_helper import ConfigHelper
 
 DEFAULT_BRUSH_SIZE = 32  # px
 DEFAULT_SHAPE_WIDTH = 50
 DEFAULT_SHAPE_HEIGHT = 50
 
-MASKS_DIR = "masks"
+MASKS_DIR = os.path.join(ConfigHelper.get_campaign_dir(), "masks")
 MAX_ZOOM = 3.0
 MIN_ZOOM = 0.1
 ZOOM_STEP = 0.1  # 10% per wheel notch

--- a/modules/npcs/npc_graph_editor.py
+++ b/modules/npcs/npc_graph_editor.py
@@ -16,6 +16,7 @@ from PIL import Image, ImageTk
 import os
 import textwrap
 from modules.ui.image_viewer import show_portrait
+from modules.helpers.config_helper import ConfigHelper
 
 ctk.set_appearance_mode("Dark")
 ctk.set_default_color_theme("blue")
@@ -23,7 +24,7 @@ ctk.set_default_color_theme("blue")
 #logging.basicConfig(level=logging.ERROR)
 
 # Constants for portrait folder and max portrait size
-PORTRAIT_FOLDER = "assets/portraits"
+PORTRAIT_FOLDER = os.path.join(ConfigHelper.get_campaign_dir(), "assets", "portraits")
 MAX_PORTRAIT_SIZE = (64, 64)
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -208,6 +209,10 @@ class NPCGraphEditor(ctk.CTkFrame):
 
         portrait_path = npc_data.get("Portrait", "")
        #logging.debug(f"Portrait path: {portrait_path}")
+        if portrait_path and not os.path.isabs(portrait_path):
+            candidate = os.path.join(ConfigHelper.get_campaign_dir(), portrait_path)
+            if os.path.exists(candidate):
+                portrait_path = candidate
         if not portrait_path or not os.path.exists(portrait_path):
             messagebox.showerror("Error", "No valid portrait found for this NPC.")
            #logging.error("No valid portrait found.")
@@ -760,6 +765,10 @@ class NPCGraphEditor(ctk.CTkFrame):
             portrait_img = None
             p_w = p_h = 0
             portrait_path = data.get("Portrait", "")
+            if portrait_path and not os.path.isabs(portrait_path):
+                candidate = os.path.join(ConfigHelper.get_campaign_dir(), portrait_path)
+                if os.path.exists(candidate):
+                    portrait_path = candidate
             if portrait_path and os.path.exists(portrait_path):
                 img = Image.open(portrait_path)
                 ow, oh = img.size
@@ -1301,6 +1310,10 @@ class NPCGraphEditor(ctk.CTkFrame):
         messagebox.showinfo("Saved", f"Graph saved to:\n{path}")
 
     def load_portrait_scaled(self, portrait_path, node_tag, scale=1.0):
+        if portrait_path and not os.path.isabs(portrait_path):
+            candidate = os.path.join(ConfigHelper.get_campaign_dir(), portrait_path)
+            if os.path.exists(candidate):
+                portrait_path = candidate
         if not portrait_path or not os.path.exists(portrait_path):
             return None, (0, 0)
         try:

--- a/modules/pcs/pc_graph_editor.py
+++ b/modules/pcs/pc_graph_editor.py
@@ -18,6 +18,7 @@ import textwrap
 import re
 from tkinter.font import Font  # add at top of file
 from modules.ui.image_viewer import show_portrait
+from modules.helpers.config_helper import ConfigHelper
 
 ctk.set_appearance_mode("Dark")
 ctk.set_default_color_theme("blue")
@@ -39,7 +40,7 @@ def get_monitors():
 #logging.basicConfig(level=logging.ERROR)
 
 # Constants for portrait folder and max portrait size
-PORTRAIT_FOLDER = "assets/portraits"
+PORTRAIT_FOLDER = os.path.join(ConfigHelper.get_campaign_dir(), "assets", "portraits")
 MAX_PORTRAIT_SIZE = (64, 64)
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -155,6 +156,10 @@ class PCGraphEditor(ctk.CTkFrame):
 
         # 3) Grab the portrait path
         portrait_path = npc_data.get("Portrait", "")
+        if portrait_path and not os.path.isabs(portrait_path):
+            candidate = os.path.join(ConfigHelper.get_campaign_dir(), portrait_path)
+            if os.path.exists(candidate):
+                portrait_path = candidate
         if not portrait_path or not os.path.exists(portrait_path):
             messagebox.showerror("Error", "No valid portrait found for this NPC.")
             return

--- a/modules/scenarios/gm_screen_view.py
+++ b/modules/scenarios/gm_screen_view.py
@@ -12,10 +12,11 @@ from modules.generic.entity_detail_factory import create_entity_detail_frame
 from modules.npcs.npc_graph_editor import NPCGraphEditor
 from modules.pcs.pc_graph_editor import PCGraphEditor
 from modules.scenarios.scenario_graph_editor import ScenarioGraphEditor
-from modules.generic.generic_list_selection_view import GenericListSelectionView   
+from modules.generic.generic_list_selection_view import GenericListSelectionView
+from modules.helpers.config_helper import ConfigHelper
 import random
 
-PORTRAIT_FOLDER = "assets/portraits"
+PORTRAIT_FOLDER = os.path.join(ConfigHelper.get_campaign_dir(), "assets", "portraits")
 MAX_PORTRAIT_SIZE = (64, 64)  # Thumbnail size for lists
 
 class GMScreenView(ctk.CTkFrame):

--- a/modules/scenarios/scenario_graph_editor.py
+++ b/modules/scenarios/scenario_graph_editor.py
@@ -22,7 +22,7 @@ from modules.ui.image_viewer import show_portrait
 from modules.helpers.template_loader import load_template
 
 # Global constants
-PORTRAIT_FOLDER = "assets/portraits"
+PORTRAIT_FOLDER = os.path.join(ConfigHelper.get_campaign_dir(), "assets", "portraits")
 MAX_PORTRAIT_SIZE = (128, 128)
 ctk.set_appearance_mode("Dark")
 ctk.set_default_color_theme("blue")

--- a/modules/ui/image_viewer.py
+++ b/modules/ui/image_viewer.py
@@ -1,5 +1,6 @@
 # modules/ui/image_viewer.py
 import os, ctypes
+from modules.helpers.config_helper import ConfigHelper
 from ctypes import wintypes
 import tkinter as tk
 import customtkinter as ctk
@@ -29,6 +30,10 @@ def show_portrait(path, title=None):
     Display a full‑screen CTkToplevel showing the image at `path`.
     Clicking anywhere closes the window.
     """
+    if path and not os.path.isabs(path):
+        candidate = os.path.join(ConfigHelper.get_campaign_dir(), path)
+        if os.path.exists(candidate):
+            path = candidate
     if not path or not os.path.exists(path):
         tk.messagebox.showerror("Error", "No valid portrait available.")
         return

--- a/modules/web/GM_webviewer.py
+++ b/modules/web/GM_webviewer.py
@@ -241,7 +241,7 @@ app.register_blueprint(journal_bp)
 # Directories for assets
 # ──────────────────────────────────────────────────────────────────────────────
 CURRENT_DIR    = os.path.dirname(__file__)
-BASE_DIR       = os.path.abspath(os.path.join(CURRENT_DIR, "..", ".."))
+BASE_DIR       = os.path.dirname(DB_PATH)
 GRAPH_DIR      = os.path.join(BASE_DIR, "assets", "graphs")
 PORTRAITS_DIR  = os.path.join(BASE_DIR, "assets", "portraits")
 FALLBACK_PORTRAIT = "/assets/images/fallback.png"


### PR DESCRIPTION
## Summary
- track campaign directory via `ConfigHelper.get_campaign_dir`
- save portraits, maps, uploads and fog masks in per-campaign folders
- resolve portrait locations from the campaign directory when displaying
- update web viewer and various editors to use the campaign data path

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841ffe3d108832b9eaf5663dcb32527