### PR TITLE
Add web display for map module

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -11,6 +11,7 @@ from modules.maps.services.fog_manager import _set_fog, clear_fog, reset_fog, on
 # from modules.maps.services.token_manager import add_token, _on_token_press, _on_token_move, _on_token_release, _copy_token, _paste_token, _show_token_menu, _resize_token_dialog, _change_token_border_color, _delete_token, _persist_tokens
 from modules.maps.services.token_manager import add_token, _persist_tokens, _change_token_border_color # Keep this if it's used by other token_manager functions not moved
 from modules.maps.views.fullscreen_view import open_fullscreen, _update_fullscreen_map
+from modules.maps.views.web_display_view import open_web_display, _update_web_display_map
 from modules.maps.services.entity_picker_service import open_entity_picker, on_entity_selected
 from modules.maps.utils.icon_loader import load_icon
 from PIL import Image, ImageTk, ImageDraw
@@ -365,7 +366,10 @@ class DisplayMapController:
                     elif item_type == "oval": shape_id = self.canvas.create_oval(sx, sy, sx + shape_width, sy + shape_height, fill=fill_color, outline=border_color, width=2)
                     item['canvas_ids'] = (shape_id,) if shape_id else ();
                     if shape_id: self._bind_item_events(item)
-        if self.fs_canvas: self._update_fullscreen_map()
+        if self.fs_canvas:
+            self._update_fullscreen_map()
+        if getattr(self, '_web_server_thread', None):
+            self._update_web_display_map()
 
     def _bind_item_events(self, item):
         if not item.get('canvas_ids'): return
@@ -691,6 +695,8 @@ class DisplayMapController:
         try:
             if getattr(self, 'fs_canvas', None) and self.fs_canvas.winfo_exists():
                 self._update_fullscreen_map()
+            if getattr(self, '_web_server_thread', None):
+                self._update_web_display_map()
         except tk.TclError:
             pass
 
@@ -835,6 +841,8 @@ class DisplayMapController:
         try:
             if getattr(self, 'fs', None) and self.fs.winfo_exists() and \
                getattr(self, 'fs_canvas', None) and self.fs_canvas.winfo_exists(): self._update_fullscreen_map()
+            if getattr(self, '_web_server_thread', None):
+                self._update_web_display_map()
         except tk.TclError: pass
             
     def _on_drawing_tool_change(self, selected_tool: str):
@@ -911,6 +919,7 @@ class DisplayMapController:
     _set_fog = _set_fog
     _show_token_menu = _show_token_menu # Token-specific context menu
     _update_fullscreen_map = _update_fullscreen_map
+    _update_web_display_map = _update_web_display_map
     add_token = add_token # For adding new entity tokens
     clear_fog = clear_fog
     load_icon = load_icon
@@ -918,6 +927,7 @@ class DisplayMapController:
     on_paint = on_paint # For fog
     open_entity_picker = open_entity_picker
     open_fullscreen = open_fullscreen
+    open_web_display = open_web_display
     reset_fog = reset_fog
     select_map = select_map
 

--- a/modules/maps/services/token_manager.py
+++ b/modules/maps/services/token_manager.py
@@ -48,6 +48,8 @@ def add_token(self, path, entity_type, entity_name, entity_record=None):
 
     if getattr(self, "fs_canvas", None) and self.fs_canvas.winfo_exists():
         self._update_fullscreen_map()
+    if getattr(self, '_web_server_thread', None):
+        self._update_web_display_map()
 
 def _on_token_press(self, event, token):
     # mark this as the “selected” token for copy/paste
@@ -175,6 +177,8 @@ def _resize_token_dialog(self, token):
     self._update_canvas_images()
     if getattr(self, "fs_canvas", None):
         self._update_fullscreen_map()
+    if getattr(self, '_web_server_thread', None):
+        self._update_web_display_map()
 
     # 3) persist both tokens *and* the global slider
     self._persist_tokens()

--- a/modules/maps/views/fullscreen_view.py
+++ b/modules/maps/views/fullscreen_view.py
@@ -192,3 +192,9 @@ def _update_fullscreen_map(self):
         self.fs_canvas.delete(self.fs_mask_id)
         self.fs_mask_id = None
 
+    if hasattr(self, '_update_web_display_map'):
+        try:
+            self._update_web_display_map()
+        except Exception:
+            pass
+

--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -43,6 +43,8 @@ def _build_toolbar(self):
         .pack(side="left", padx=2)
     create_icon_button(toolbar, icons["fs"],    "Fullscreen",   command=self.open_fullscreen)\
         .pack(side="left", padx=2)
+    create_icon_button(toolbar, icons["fs"],    "Web Display",   command=self.open_web_display)\
+        .pack(side="left", padx=2)
 
     # Brush shape selector (for fog)
     shape_label = ctk.CTkLabel(toolbar, text="Fog Shape:") # Clarified label

--- a/modules/maps/views/web_display_view.py
+++ b/modules/maps/views/web_display_view.py
@@ -1,0 +1,90 @@
+import io
+import threading
+from flask import Flask, send_file
+from PIL import Image, ImageDraw
+
+# Simple Flask app to serve the current map image
+
+def open_web_display(self, port=5001):
+    if getattr(self, '_web_server_thread', None):
+        return  # already running
+    self._web_app = Flask(__name__)
+
+    controller = self
+
+    @self._web_app.route('/')
+    def index():
+        return '<img src="/map.png" style="max-width:100%;">'
+
+    @self._web_app.route('/map.png')
+    def map_png():
+        controller._update_web_display_map()
+        buf = io.BytesIO(controller._web_image_bytes)
+        return send_file(buf, mimetype='image/png', cache_timeout=0)
+
+    def run_app():
+        self._web_app.run(host='0.0.0.0', port=port, threaded=True, use_reloader=False)
+
+    self._web_server_thread = threading.Thread(target=run_app, daemon=True)
+    self._web_server_thread.start()
+
+
+def _render_map_image(self):
+    if not self.base_img:
+        return None
+    w, h = self.base_img.size
+    sw, sh = int(w * self.zoom), int(h * self.zoom)
+    x0, y0 = int(self.pan_x), int(self.pan_y)
+    min_x, min_y = min(0, x0), min(0, y0)
+    max_x, max_y = max(sw, x0 + sw), max(sh, y0 + sh)
+    width, height = max_x - min_x, max_y - min_y
+    img = Image.new('RGBA', (width, height), (0, 0, 0, 255))
+    base_resized = self.base_img.resize((sw, sh), Image.LANCZOS)
+    img.paste(base_resized, (x0 - min_x, y0 - min_y))
+
+    draw = ImageDraw.Draw(img)
+    for item in self.tokens:
+        item_type = item.get('type', 'token')
+        xw, yw = item.get('position', (0, 0))
+        sx = int(xw * self.zoom + self.pan_x - min_x)
+        sy = int(yw * self.zoom + self.pan_y - min_y)
+        if item_type == 'token':
+            pil = item.get('pil_image')
+            if pil:
+                tw, th = pil.size
+                nw, nh = int(tw * self.zoom), int(th * self.zoom)
+                img_r = pil.resize((nw, nh), Image.LANCZOS)
+                img.paste(img_r, (sx, sy), img_r.convert('RGBA'))
+                draw.rectangle([sx - 3, sy - 3, sx + nw + 3, sy + nh + 3], outline=item.get('border_color', '#0000ff'), width=3)
+        elif item_type in ['rectangle', 'oval']:
+            shape_w = int(item.get('width', 50) * self.zoom)
+            shape_h = int(item.get('height', 50) * self.zoom)
+            fill_color = item.get('fill_color', '') if item.get('is_filled', True) else ''
+            border_color = item.get('border_color', '#000000')
+            if item_type == 'rectangle':
+                draw.rectangle([sx, sy, sx + shape_w, sy + shape_h], fill=fill_color, outline=border_color, width=2)
+            else:
+                draw.ellipse([sx, sy, sx + shape_w, sy + shape_h], fill=fill_color, outline=border_color, width=2)
+
+    if self.mask_img:
+        mask_copy = self.mask_img.copy()
+        _, _, _, alpha = mask_copy.split()
+        processed_alpha = alpha.point(lambda a: 255 if a > 0 else 0)
+        mask_copy.putalpha(processed_alpha)
+        mask_resized = mask_copy.resize((sw, sh), Image.LANCZOS)
+        img.paste(mask_resized, (x0 - min_x, y0 - min_y), mask_resized)
+
+    return img
+
+
+def _update_web_display_map(self):
+    if not getattr(self, '_web_server_thread', None):
+        return
+    img = _render_map_image(self)
+    if img is None:
+        return
+    buf = io.BytesIO()
+    img.save(buf, format='PNG')
+    self._web_image_bytes = buf.getvalue()
+    buf.close()
+


### PR DESCRIPTION
## Summary
- implement simple Flask-based web display
- update fullscreen map update to refresh web display
- add Web Display button in toolbar
- integrate web display updates across controller and token manager

## Testing
- `python -m py_compile modules/maps/views/web_display_view.py`
- `python -m py_compile modules/maps/controllers/display_map_controller.py modules/maps/views/fullscreen_view.py modules/maps/views/toolbar_view.py modules/maps/services/token_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684884da86e0832b96acd14ec42e94d5