### PR TITLE
Configurable map web server port

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -11,3 +11,6 @@ model = Dungeons_and_Diffusion_v3_-_v3
 [Database]
 path = D:/SynologyDrive/rpg/Python/GMCampaignDesigner2/Campaigns/DresdenFiles/Dresden_Files.db
 
+
+[Server]
+map_port = 32000

--- a/modules/maps/views/map_selector.py
+++ b/modules/maps/views/map_selector.py
@@ -236,3 +236,5 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
 
     # 9) Finally draw everything onto the canvas
     self._update_canvas_images()
+    if getattr(self, '_web_server_thread', None):
+        self._update_web_display_map()

--- a/modules/maps/views/web_display_view.py
+++ b/modules/maps/views/web_display_view.py
@@ -2,10 +2,13 @@ import io
 import threading
 from flask import Flask, send_file
 from PIL import Image, ImageDraw
+from modules.helpers.config_helper import ConfigHelper
 
 # Simple Flask app to serve the current map image
 
-def open_web_display(self, port=32000):
+def open_web_display(self, port=None):
+    if port is None:
+        port = int(ConfigHelper.get("Server", "map_port", fallback=32000))
     if getattr(self, '_web_server_thread', None):
         return  # already running
     self._web_app = Flask(__name__)

--- a/modules/web/GM_webviewer.py
+++ b/modules/web/GM_webviewer.py
@@ -675,4 +675,5 @@ def edit_clue(idx):
 if __name__ == '__main__':
     with app.app_context():
         db.create_all()
-    app.run(host='0.0.0.0', port=31000, debug=True)
+    port = int(ConfigHelper.get('Server', 'map_port', fallback=31000))
+    app.run(host='0.0.0.0', port=port, debug=True)


### PR DESCRIPTION
## Summary
- add a `[Server]` section to `config.ini` with `map_port`
- read the port from config in `web_display_view.open_web_display`
- refresh web display whenever a new map is loaded
- use the configured port for `GM_webviewer` too

## Testing
- `python -m py_compile modules/maps/views/web_display_view.py modules/maps/views/map_selector.py modules/web/GM_webviewer.py`

------
https://chatgpt.com/codex/tasks/task_e_6849baa93edc832b89faa14e1dbaef3c