### PR TITLE
Improve map server shutdown logic

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -7,7 +7,7 @@ import requests
 import shutil
 import tkinter as tk
 from tkinter import filedialog, messagebox, Toplevel, Listbox, MULTIPLE, PhotoImage
-#import logging
+import logging
 
 import customtkinter as ctk
 from PIL import Image, ImageTk
@@ -1286,7 +1286,7 @@ class MainWindow(ctk.CTk):
             try:
                 self.map_controller.close_web_display()
             except Exception:
-                pass
+                logging.exception("Error while closing web display")
             top.destroy()
 
         top.protocol("WM_DELETE_WINDOW", _on_close)

--- a/modules/maps/views/web_display_view.py
+++ b/modules/maps/views/web_display_view.py
@@ -1,5 +1,6 @@
 import io
 import threading
+import logging
 import requests
 from flask import Flask, send_file, request
 from PIL import Image, ImageDraw
@@ -153,10 +154,13 @@ def close_web_display(self, port=None):
         # Ignore errors if the server is already stopped
         pass
 
-    thread.join(timeout=1)
-    if thread.is_alive():
-        # Give it another chance to shut down gracefully
+    for _ in range(5):  # wait up to ~5 seconds total
         thread.join(timeout=1)
+        if not thread.is_alive():
+            break
 
-    self._web_server_thread = None
-    self._web_app = None
+    if thread.is_alive():
+        logging.warning("Web display server did not shut down within timeout.")
+    else:
+        self._web_server_thread = None
+        self._web_app = None


### PR DESCRIPTION
## Summary
- ensure map web display server shutdown loop waits up to 5 seconds
- warn if the server is still alive after waiting
- only null-out server attributes when the thread stops
- log errors during map window close

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6e43f498832b997951f6c18f2f86