### PR TITLE
Remove duplicate combobox binding

### DIFF
--- a/modules/generic/generic_editor_window.py
+++ b/modules/generic/generic_editor_window.py
@@ -724,7 +724,6 @@ class GenericEditorWindow(ctk.CTkToplevel):
 
             # open the dropdown on click *or* focus for EVERY dynamic combobox:
             entry.bind("<Button-1>",  lambda e, w=entry, v=var: open_dropdown(w, v))
-            entry.bind("<Button-1>", lambda e, w=entry, v=var: open_dropdown(w, v))
 
             if initial_value and initial_value in options_list:
                 var.set(initial_value)


### PR DESCRIPTION
## Summary
- remove extra `<Button-1>` binding in `GenericEditorWindow.add_combobox`

## Testing
- `python -m py_compile modules/generic/generic_editor_window.py`

------
https://chatgpt.com/codex/tasks/task_e_686109f62438832bb43fd9da481d98c9