### PR TITLE
Fix ConfigHelper caching

### DIFF
--- a/modules/helpers/config_helper.py
+++ b/modules/helpers/config_helper.py
@@ -7,16 +7,19 @@ class ConfigHelper:
 
     @classmethod
     def load_config(cls, file_path="config/config.ini"):
-        cls._config = configparser.ConfigParser()
-        if os.path.exists(file_path):
-            cls._config.read(file_path)
-        else:
-            print(f"Warning: config file '{file_path}' not found.")
+        """Load the configuration from ``file_path`` if it hasn't been loaded."""
+        if cls._config is None:
+            cls._config = configparser.ConfigParser()
+            if os.path.exists(file_path):
+                cls._config.read(file_path)
+            else:
+                print(f"Warning: config file '{file_path}' not found.")
         return cls._config
 
     @classmethod
     def get(cls, section, key, fallback=None):
-        cls.load_config()
+        if cls._config is None:
+            cls.load_config()
         try:
             return cls._config.get(section, key, fallback=fallback)
         except Exception as e:


### PR DESCRIPTION
## Summary
- load configuration only once
- avoid re-reading the config file on each `get`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686109eb4494832bad44538fb5246118