### PR TITLE
Add scenario generator with export and DB integration

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -28,6 +28,7 @@ from modules.npcs.npc_graph_editor import NPCGraphEditor
 from modules.pcs.pc_graph_editor import PCGraphEditor
 from modules.scenarios.scenario_graph_editor import ScenarioGraphEditor
 from modules.scenarios.scenario_importer import ScenarioImportWindow
+from modules.scenarios.scenario_generator_view import ScenarioGeneratorView
 from modules.generic.export_for_foundry import preview_and_export_foundry
 from modules.helpers import text_helpers
 from db.db import load_schema_from_json, initialize_db
@@ -110,6 +111,7 @@ class MainWindow(ctk.CTk):
             "import_scenario": self.load_icon("import_icon.png", size=(60, 60)),
             "export_foundry": self.load_icon("export_foundry_icon.png", size=(60, 60)),
             "map_tool": self.load_icon("map_tool_icon.png", size=(60, 60)),
+            "generate_scenario": self.load_icon("generate_icon.png", size=(60, 60)),
         }
 
     def load_icon(self, file_name, size=(60, 60)):
@@ -182,6 +184,7 @@ class MainWindow(ctk.CTk):
             ("pc_graph", "Open PC Graph Editor", self.open_pc_graph_editor),
             ("faction_graph", "Open Factions Graph Editor", self.open_faction_graph_editor),
             ("scenario_graph", "Open Scenario Graph Editor", self.open_scenario_graph_editor),
+            ("generate_scenario", "Generate Scenario", self.open_scenario_generator),
             ("generate_portraits", "Generate Portraits", self.generate_missing_portraits),
             ("associate_portraits", "Associate NPC Portraits", self.associate_npc_portraits),
             ("import_scenario", "Import Scenario", self.open_scenario_importer),
@@ -684,6 +687,16 @@ class MainWindow(ctk.CTk):
         container = ctk.CTkFrame(self.content_frame)
         container.grid(row=0, column=0, sticky="nsew")
         ScenarioImportWindow(container)
+
+    def open_scenario_generator(self):
+        self.clear_current_content()
+        parent = self.get_content_container()
+        container = ScenarioGeneratorView(parent)
+        container.grid(row=0, column=0, sticky="nsew")
+        parent.grid_rowconfigure(0, weight=1)
+        parent.grid_columnconfigure(0, weight=1)
+        self.current_open_view = container
+        self.current_open_entity = None
 
     def change_database_storage(self):
         # 1) Pick or create .db

--- a/modules/scenarios/scenario_generator_view.py
+++ b/modules/scenarios/scenario_generator_view.py
@@ -1,0 +1,146 @@
+from tkinter import filedialog, messagebox
+
+import customtkinter as ctk
+
+from campaign_generator import GENERATOR_FUNCTIONS, export_to_docx
+from modules.generic.generic_model_wrapper import GenericModelWrapper
+
+
+class ScenarioGeneratorView(ctk.CTkFrame):
+    """Frame embedding the scenario generator inside the main application."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+
+        # Match the dark background style from the original generator UI
+        self.configure(fg_color="#2c3e50")
+
+        self.setting_var = ctk.StringVar(value=list(GENERATOR_FUNCTIONS.keys())[0])
+        self.title_var = ctk.StringVar(value="")
+        self.current_campaign = None
+
+        self._build_widgets()
+
+    # ------------------------------------------------------------------
+    def _build_widgets(self):
+        top = ctk.CTkFrame(self)
+        top.pack(fill="x", padx=10, pady=10)
+
+        ctk.CTkLabel(top, text="Setting:").pack(side="left")
+        ctk.CTkOptionMenu(top, values=list(GENERATOR_FUNCTIONS.keys()),
+                          variable=self.setting_var).pack(side="left", padx=5)
+        ctk.CTkButton(top, text="Generate", command=self.generate_campaign).pack(side="left", padx=5)
+
+        # Scrollable area for displaying generated scenario cards
+        self.results_frame = ctk.CTkScrollableFrame(self, fg_color="#2c3e50")
+        self.results_frame.pack(fill="both", expand=True, padx=10, pady=10)
+
+        bottom = ctk.CTkFrame(self)
+        bottom.pack(fill="x", padx=10, pady=(0, 10))
+
+        ctk.CTkLabel(bottom, text="Title:").pack(side="left")
+        ctk.CTkEntry(bottom, textvariable=self.title_var).pack(side="left", padx=5, fill="x", expand=True)
+        self.export_btn = ctk.CTkButton(bottom, text="Export to DOCX",
+                                       command=self.export_docx, state="disabled")
+        self.export_btn.pack(side="left", padx=5)
+        self.add_btn = ctk.CTkButton(bottom, text="Add to DB",
+                                    command=self.add_to_db, state="disabled")
+        self.add_btn.pack(side="left", padx=5)
+
+    # ------------------------------------------------------------------
+    def generate_campaign(self):
+        setting = self.setting_var.get()
+        try:
+            generator = GENERATOR_FUNCTIONS[setting]
+            campaign = generator()
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to generate scenario: {e}")
+            return
+
+        self.current_campaign = campaign
+
+        # Clear previous results
+        for child in self.results_frame.winfo_children():
+            child.destroy()
+
+        # Display each entry as a styled card similar to the original UI
+        for key, value in campaign.items():
+            card = ctk.CTkFrame(
+                self.results_frame,
+                fg_color="#34495e",
+                corner_radius=4,
+            )
+            title_lbl = ctk.CTkLabel(
+                card,
+                text=key,
+                text_color="#ecf0f1",
+                font=("Helvetica", 14, "bold"),
+                anchor="w",
+            )
+            desc_lbl = ctk.CTkLabel(
+                card,
+                text=value,
+                text_color="#bdc3c7",
+                justify="left",
+                wraplength=1700,
+                font=("Helvetica", 11),
+            )
+            title_lbl.pack(anchor="w", padx=8, pady=(4, 0))
+            desc_lbl.pack(anchor="w", padx=8, pady=(0, 6))
+            card.pack(fill="x", expand=True, padx=5, pady=5)
+
+        self.export_btn.configure(state="normal")
+        self.add_btn.configure(state="normal")
+
+    # ------------------------------------------------------------------
+    def export_docx(self):
+        if not self.current_campaign:
+            messagebox.showwarning("No Scenario", "Generate a scenario first.")
+            return
+
+        filename = filedialog.asksaveasfilename(
+            defaultextension=".docx",
+            filetypes=[("Word Document", "*.docx")],
+            title="Save Scenario" )
+        if not filename:
+            return
+
+        try:
+            export_to_docx(self.current_campaign, filename)
+        except Exception as e:
+            messagebox.showerror("Export Error", str(e))
+            return
+
+        messagebox.showinfo("Exported", "Scenario exported to DOCX.")
+
+    # ------------------------------------------------------------------
+    def add_to_db(self):
+        if not self.current_campaign:
+            messagebox.showwarning("No Scenario", "Generate a scenario first.")
+            return
+
+        title = self.title_var.get().strip()
+        if not title:
+            messagebox.showwarning("Missing Title", "Please provide a title for the scenario.")
+            return
+
+        summary = "\n".join(f"{k}: {v}" for k, v in self.current_campaign.items())
+        scenario_entity = {
+            "Title": title,
+            "Summary": summary,
+            "Secrets": "",
+            "Places": [],
+            "NPCs": [],
+            "Objects": [],
+        }
+
+        wrapper = GenericModelWrapper("scenarios")
+        existing = wrapper.load_items()
+        if any(s.get("Title") == title for s in existing):
+            messagebox.showwarning("Duplicate Title", f"A scenario titled '{title}' already exists.")
+            return
+
+        existing.append(scenario_entity)
+        wrapper.save_items(existing)
+        messagebox.showinfo("Saved", f"Scenario '{title}' added to database.")
+


### PR DESCRIPTION
## Summary
- integrate a Scenario Generator view leveraging `campaign_generator.py`
- add sidebar button to open the generator
- enable generated scenarios to export as DOCX or save into the database
- style generator results with card layout matching the original generator UI

## Testing
- `python -m py_compile main_window.py modules/scenarios/scenario_generator_view.py`
- `pip install flask`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e2505e26c832ba20345091a53ebb5