### PR TITLE
Ensure treeview row color appears after selection

### DIFF
--- a/modules/generic/generic_list_view.py
+++ b/modules/generic/generic_list_view.py
@@ -576,6 +576,9 @@ class GenericListView(ctk.CTkFrame):
             self.tree.item(iid, tags=(f"color_{color_name}",))
         else:
             self.tree.item(iid, tags=())
+        # Deselect the row so the new color is visible immediately
+        self.tree.selection_remove(iid)
+        self.tree.focus("")
         self._save_row_color(base_id, color_name)
 
     def _save_row_color(self, base_id, color_name):


### PR DESCRIPTION
## Summary
- Deselect rows after assigning a color so the new background shows immediately

## Testing
- `python -m pytest`
- `python auto-tests/autotest.py` *(fails: ImportError: cannot import name 'Application' from 'pywinauto')*

------
https://chatgpt.com/codex/tasks/task_e_68a0516e5f78832bb454b72b8d65540e