### PR TITLE
Preserve line breaks in GM screen entity details

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -2,7 +2,7 @@ import os
 import customtkinter as ctk
 from PIL import Image
 from customtkinter import CTkLabel, CTkImage, CTkTextbox
-from modules.helpers.text_helpers import format_longtext
+from modules.helpers.text_helpers import format_longtext, format_multiline_text
 from modules.helpers.template_loader import load_template
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from tkinter import Toplevel, messagebox
@@ -55,7 +55,7 @@ def insert_longtext(parent, header, content):
         text = content.get("text", "")
     else:
         text = str(content)
-    formatted_text = format_longtext(text, max_length=2000)
+    formatted_text = format_multiline_text(text, max_length=2000)
 
     box = CTkTextbox(parent, wrap="word")
     box.insert = box._textbox.insert

--- a/modules/scenarios/gm_screen_view.py
+++ b/modules/scenarios/gm_screen_view.py
@@ -6,7 +6,7 @@ from tkinter import filedialog, messagebox
 from PIL import Image
 from functools import partial
 from modules.generic.generic_model_wrapper import GenericModelWrapper
-from modules.helpers.text_helpers import format_longtext
+from modules.helpers.text_helpers import format_multiline_text
 from customtkinter import CTkLabel, CTkImage
 from modules.generic.entity_detail_factory import create_entity_detail_frame
 from modules.npcs.npc_graph_editor import NPCGraphEditor
@@ -740,7 +740,7 @@ class GMScreenView(ctk.CTkFrame):
         
     def insert_longtext(self, parent, header, content):
         ctk.CTkLabel(parent, text=f"{header}:", font=("Arial", 14, "bold")).pack(anchor="w", padx=10)
-        formatted_text = format_longtext(content, max_length=2000)
+        formatted_text = format_multiline_text(content, max_length=2000)
         box = ctk.CTkTextbox(parent, wrap="word", height=120)
         box.insert("1.0", formatted_text)
         box.configure(state="disabled")


### PR DESCRIPTION
## Summary
- ensure long text fields keep newline formatting in the GM screen

## Testing
- `pytest`
- `python -m py_compile modules/generic/entity_detail_factory.py modules/scenarios/gm_screen_view.py`


------
https://chatgpt.com/codex/tasks/task_e_68a069420e34832bb696d1391e9887b8