### PR TITLE
feat: auto-resize longtext textboxes

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -60,18 +60,17 @@ def insert_longtext(parent, header, content):
     box = CTkTextbox(parent, wrap="word")
     box.insert = box._textbox.insert
     box.insert("1.0", formatted_text)
-    box.configure(state="disabled")
     box.pack(fill="x", padx=10, pady=5)
 
     # Resize after layout
     def update_height():
         lines = int(box._textbox.count("1.0", "end", "displaylines")[0])
-        #font = tkfont.nametofont(box._textbox.cget("font"))
-        #line_px = font.metrics("linespace")
-        clamped = max(2, min(lines, 2))
-        box.configure(height=100)
+        font = tkfont.nametofont(box._textbox.cget("font"))
+        line_px = font.metrics("linespace")
+        box.configure(height=max(2, lines) * line_px)
+        box.configure(state="disabled")
 
-    box.after(100, update_height)
+    box.after_idle(update_height)
 
 def insert_links(parent, header, items, linked_type, open_entity_callback):
     ctk.CTkLabel(parent, text=f"{header}:", font=("Arial", 14, "bold")).pack(anchor="w", padx=10)


### PR DESCRIPTION
## Summary
- dynamically compute CTkTextbox height using displayed line count and font metrics in `insert_longtext`
- delay disabling textbox until after sizing and schedule resize with `after_idle`

## Testing
- `pytest`
- `xvfb-run -a python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a06d748d20832ba86d48f3580bb99b